### PR TITLE
Compilation error fix

### DIFF
--- a/app/xevd_app.c
+++ b/app/xevd_app.c
@@ -297,7 +297,7 @@ static int write_y4m_header(char * fname, XEVD_IMGB * img)
         if (bit_depth == 8)  strcpy(c_buf, "mono");
     }
 
-    if (c_buf == NULL)
+    if (c_buf[0] == 0)
     {
         logv0("Color format is not suuported by y4m");
         return XEVD_ERR;


### PR DESCRIPTION
Fix for "-Werror=Address" (gcc 12.2.0)
```c_buf[16]``` is allocated therefore ```c_buf == NULL``` statement is always false.

edit: typo